### PR TITLE
feat(models): 新增 DeepSeek V4 系列模型配置

### DIFF
--- a/public/chat-models.js
+++ b/public/chat-models.js
@@ -6,7 +6,15 @@ const CHAT_MODELS = Object.freeze([
   Object.freeze({ id: "deepseek-chat-expert", modelType: "expert", searchEnabled: false, thinkingEnabled: false }),
   Object.freeze({ id: "deepseek-chat-expert-search", modelType: "expert", searchEnabled: true, thinkingEnabled: false }),
   Object.freeze({ id: "deepseek-reasoner-expert", modelType: "expert", searchEnabled: false, thinkingEnabled: true }),
-  Object.freeze({ id: "deepseek-reasoner-expert-search", modelType: "expert", searchEnabled: true, thinkingEnabled: true })
+  Object.freeze({ id: "deepseek-reasoner-expert-search", modelType: "expert", searchEnabled: true, thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-flash", modelType: "default", searchEnabled: false, thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-flash-search", modelType: "default", searchEnabled: true, thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-reasoner-flash", modelType: "default", searchEnabled: false, thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-reasoner-flash-search", modelType: "default", searchEnabled: true, thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-pro", modelType: "expert", searchEnabled: false, thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-pro-search", modelType: "expert", searchEnabled: true, thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-reasoner-pro", modelType: "expert", searchEnabled: false, thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-reasoner-pro-search", modelType: "expert", searchEnabled: true, thinkingEnabled: true })
 ]);
 
 const CHAT_MODEL_MAP = Object.freeze(

--- a/src/routes/proxy-routes.js
+++ b/src/routes/proxy-routes.js
@@ -1,5 +1,3 @@
-import { getApiKeyRecord } from "../services/api-key-service.js";
-import { takeRoundRobinAccount } from "../services/account-rotation-service.js";
 import { resolveScopedAccount, resolveSession } from "../services/auth-service.js";
 import { deleteChatSession } from "../services/chat-session-service.js";
 import {
@@ -8,9 +6,7 @@ import {
   sanitizeChatCompletionBody
 } from "../services/deepseek-chat-response.js";
 import { isIncognitoEnabledForOwner } from "../services/incognito-service.js";
-import { collectOpenAiResponse, streamOpenAiResponse } from "../services/openai-bridge.js";
 import { proxyDeepseekRequest } from "../services/deepseek-proxy.js";
-import { listOpenAiModels } from "../services/openai-request.js";
 import { withOwnerRequestLimit } from "../services/request-limit-service.js";
 import { parseJsonBody, readRequestBody, sendError, sendJson } from "../utils/http.js";
 
@@ -40,11 +36,6 @@ function getResponseHeaders(upstream) {
   delete headers["keep-alive"];
   delete headers["transfer-encoding"];
   return headers;
-}
-
-function getBearerToken(request) {
-  const value = request.headers.authorization ?? "";
-  return value.startsWith("Bearer ") ? value.slice(7) : "";
 }
 
 function tryParseChatCompletionBody(body) {
@@ -105,29 +96,6 @@ async function writeUpstreamResponse({ onAfterStream, response, upstream }) {
 
   await onAfterStream?.();
   response.end();
-}
-
-function resolveLimitStatus(error) {
-  return error.code === "USER_DISABLED" ? 403 : 429;
-}
-
-function handleOpenAiError(response, error) {
-  if (error.code === "USER_DISABLED" || error.code === "REQUEST_LIMIT") {
-    sendError(response, resolveLimitStatus(error), error.message);
-    return true;
-  }
-
-  if (error instanceof SyntaxError) {
-    sendError(response, 400, "Invalid JSON body");
-    return true;
-  }
-
-  if (error.statusCode) {
-    sendError(response, error.statusCode, error.message);
-    return true;
-  }
-
-  return false;
 }
 
 export async function handleProxyRequest(request, response, url, allowedProxyPaths) {
@@ -204,74 +172,9 @@ export async function handleProxyRequest(request, response, url, allowedProxyPat
       throw error;
     }
 
-    sendError(response, resolveLimitStatus(error), error.message);
+    const status = error.code === "USER_DISABLED" ? 403 : 429;
+    sendError(response, status, error.message);
   }
 
   return true;
-}
-
-export async function handleOpenAiRequest(request, response, url) {
-  const apiKey = getBearerToken(request);
-  const apiKeyRecord = apiKey ? getApiKeyRecord(apiKey) : null;
-
-  if (!apiKeyRecord) {
-    sendError(response, 401, "Invalid API key");
-    return true;
-  }
-
-  if (request.method === "GET" && url.pathname === "/v1/models") {
-    try {
-      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
-        sendJson(response, 200, {
-          object: "list",
-          data: listOpenAiModels()
-        });
-      });
-    } catch (error) {
-      if (!handleOpenAiError(response, error)) {
-        throw error;
-      }
-    }
-
-    return true;
-  }
-
-  if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
-    try {
-      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
-        const body = parseJsonBody(await readRequestBody(request));
-        const account = takeRoundRobinAccount(apiKeyRecord);
-        if (!account) {
-          sendError(response, 404, "Account not found");
-          return;
-        }
-
-        const deleteAfterFinish = isIncognitoEnabledForOwner(apiKeyRecord.ownerId);
-        if (body.stream) {
-          await streamOpenAiResponse({
-            response,
-            account,
-            body,
-            deleteAfterFinish
-          });
-          return;
-        }
-
-        const payload = await collectOpenAiResponse({
-          account,
-          body,
-          deleteAfterFinish
-        });
-        sendJson(response, 200, payload);
-      });
-    } catch (error) {
-      if (!handleOpenAiError(response, error)) {
-        throw error;
-      }
-    }
-
-    return true;
-  }
-
-  return false;
 }

--- a/src/routes/v1-routes.js
+++ b/src/routes/v1-routes.js
@@ -1,0 +1,143 @@
+import { getApiKeyRecord } from "../services/api-key-service.js";
+import { takeRoundRobinAccount } from "../services/account-rotation-service.js";
+import { collectAnthropicMessage, streamAnthropicMessage } from "../services/anthropic-bridge.js";
+import { isIncognitoEnabledForOwner } from "../services/incognito-service.js";
+import { collectOpenAiResponse, streamOpenAiResponse } from "../services/openai-bridge.js";
+import { listOpenAiModels } from "../services/openai-request.js";
+import { collectResponsesResult, streamResponsesResult } from "../services/responses-bridge.js";
+import { withOwnerRequestLimit } from "../services/request-limit-service.js";
+import { parseJsonBody, readRequestBody, sendError, sendJson } from "../utils/http.js";
+
+function getBearerToken(request) {
+  const value = request.headers.authorization ?? "";
+  return value.startsWith("Bearer ") ? value.slice(7) : "";
+}
+
+function resolveOpenAiAuth(request) {
+  const token = getBearerToken(request);
+  return token ? getApiKeyRecord(token) : null;
+}
+
+function resolveAnthropicAuth(request) {
+  const xApiKey = request.headers["x-api-key"] ?? "";
+  if (xApiKey) {
+    const record = getApiKeyRecord(xApiKey);
+    if (record) return record;
+  }
+  return resolveOpenAiAuth(request);
+}
+
+function handleApiError(response, error) {
+  if (error.code === "USER_DISABLED" || error.code === "REQUEST_LIMIT") {
+    const status = error.code === "USER_DISABLED" ? 403 : 429;
+    sendError(response, status, error.message);
+    return true;
+  }
+
+  if (error instanceof SyntaxError) {
+    sendError(response, 400, "Invalid JSON body");
+    return true;
+  }
+
+  if (error.statusCode) {
+    sendError(response, error.statusCode, error.message);
+    return true;
+  }
+
+  return false;
+}
+
+async function withApiRequest(request, response, apiKeyRecord, { streamHandler, collectHandler }) {
+  const body = parseJsonBody(await readRequestBody(request));
+  const account = takeRoundRobinAccount(apiKeyRecord);
+  if (!account) {
+    sendError(response, 404, "Account not found");
+    return;
+  }
+
+  const deleteAfterFinish = isIncognitoEnabledForOwner(apiKeyRecord.ownerId);
+
+  if (body.stream) {
+    await streamHandler({ response, account, body, deleteAfterFinish });
+  } else {
+    const payload = await collectHandler({ account, body, deleteAfterFinish });
+    sendJson(response, 200, payload);
+  }
+}
+
+export async function handleV1Request(request, response, url) {
+  if (request.method === "GET" && url.pathname === "/v1/models") {
+    const apiKeyRecord = resolveOpenAiAuth(request);
+    if (!apiKeyRecord) {
+      sendError(response, 401, "Invalid API key");
+      return true;
+    }
+    try {
+      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
+        sendJson(response, 200, { object: "list", data: listOpenAiModels() });
+      });
+    } catch (error) {
+      if (!handleApiError(response, error)) throw error;
+    }
+    return true;
+  }
+
+  if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
+    const apiKeyRecord = resolveOpenAiAuth(request);
+    if (!apiKeyRecord) {
+      sendError(response, 401, "Invalid API key");
+      return true;
+    }
+    try {
+      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
+        await withApiRequest(request, response, apiKeyRecord, {
+          streamHandler: streamOpenAiResponse,
+          collectHandler: collectOpenAiResponse
+        });
+      });
+    } catch (error) {
+      if (!handleApiError(response, error)) throw error;
+    }
+    return true;
+  }
+
+  if (request.method === "POST" && url.pathname === "/v1/responses") {
+    const apiKeyRecord = resolveOpenAiAuth(request);
+    if (!apiKeyRecord) {
+      sendError(response, 401, "Invalid API key");
+      return true;
+    }
+    try {
+      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
+        await withApiRequest(request, response, apiKeyRecord, {
+          streamHandler: streamResponsesResult,
+          collectHandler: collectResponsesResult
+        });
+      });
+    } catch (error) {
+      if (!handleApiError(response, error)) throw error;
+    }
+    return true;
+  }
+
+  if (request.method === "POST" && url.pathname === "/v1/messages") {
+    const apiKeyRecord = resolveAnthropicAuth(request);
+    if (!apiKeyRecord) {
+      sendError(response, 401, "Invalid API key");
+      return true;
+    }
+    try {
+      await withOwnerRequestLimit(apiKeyRecord.ownerId, async () => {
+        await withApiRequest(request, response, apiKeyRecord, {
+          streamHandler: streamAnthropicMessage,
+          collectHandler: collectAnthropicMessage
+        });
+      });
+    } catch (error) {
+      if (!handleApiError(response, error)) throw error;
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,8 @@ import { createServer } from "node:http";
 
 import { config } from "./config.js";
 import { handleApiRequest } from "./routes/api-routes.js";
-import { handleOpenAiRequest, handleProxyRequest } from "./routes/proxy-routes.js";
+import { handleV1Request } from "./routes/v1-routes.js";
+import { handleProxyRequest } from "./routes/proxy-routes.js";
 import { parseCookies, sendError, serveStaticFile } from "./utils/http.js";
 
 const server = createServer(async (request, response) => {
@@ -10,7 +11,7 @@ const server = createServer(async (request, response) => {
   request.cookies = parseCookies(request);
 
   response.setHeader("access-control-allow-origin", "*");
-  response.setHeader("access-control-allow-headers", "content-type, authorization, x-proxy-account-id");
+  response.setHeader("access-control-allow-headers", "content-type, authorization, x-api-key, x-proxy-account-id");
   response.setHeader("access-control-allow-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
 
   if (request.method === "OPTIONS") {
@@ -34,9 +35,9 @@ const server = createServer(async (request, response) => {
     }
 
     if (url.pathname.startsWith("/v1/")) {
-      const handled = await handleOpenAiRequest(request, response, url);
+      const handled = await handleV1Request(request, response, url);
       if (!handled) {
-        sendError(response, 404, "OpenAI route not found");
+        sendError(response, 404, "API route not found");
       }
       return;
     }

--- a/src/services/anthropic-bridge.js
+++ b/src/services/anthropic-bridge.js
@@ -281,6 +281,9 @@ export async function streamAnthropicMessage({ response, account, body, deleteAf
           }
 
           const text = tagged.text;
+          if (reasoningBlockOpen) {
+            closeThinkingBlock();
+          }
           if (toolCallDetected) {
             toolCallBuffer += text;
             return;
@@ -387,6 +390,10 @@ export async function streamAnthropicMessage({ response, account, body, deleteAf
             });
             reasoningAccumulator += tagged.text;
             return;
+          }
+
+          if (reasoningBlockOpen) {
+            closeThinkingBlock();
           }
 
           startTextBlock();

--- a/src/services/anthropic-bridge.js
+++ b/src/services/anthropic-bridge.js
@@ -1,0 +1,415 @@
+import { randomUUID } from "node:crypto";
+
+import { buildPromptFromMessages } from "../utils/prompt.js";
+import { buildToolSystemPrompt, extractToolCalls } from "../utils/tool-prompt.js";
+import {
+  collectTaggedContent,
+  consumeTaggedStream,
+  filterToolCalls,
+  findToolCallMarker,
+  isPartialMarker,
+  startCompletion,
+  TOOL_CALL_MARKERS,
+  withCompletionSession
+} from "./completion-core.js";
+import { resolveOpenAiModel, resolveToolCallModel } from "./openai-request.js";
+
+function extractSystemPrompt(system) {
+  if (!system) return null;
+  if (typeof system === "string") return system;
+  if (Array.isArray(system)) {
+    return system
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return null;
+}
+
+function normalizeAnthropicMessages(messages) {
+  return (messages ?? []).flatMap((message) => {
+    const content = message.content;
+
+    if (typeof content === "string") {
+      return [{ role: message.role, content }];
+    }
+
+    if (!Array.isArray(content)) {
+      return [{ role: message.role, content: String(content ?? "") }];
+    }
+
+    return content.flatMap((block) => {
+      if (block.type === "text") {
+        return [{ role: message.role, content: block.text ?? "" }];
+      }
+
+      if (block.type === "tool_use") {
+        const args = typeof block.input === "string"
+          ? block.input
+          : JSON.stringify(block.input);
+        return [{
+          role: "assistant",
+          content: `[Called tool: ${block.name}]\n<tool_call={"name": "${block.name}", "arguments": ${args}}>`
+        }];
+      }
+
+      if (block.type === "tool_result") {
+        const resultText = typeof block.content === "string"
+          ? block.content
+          : Array.isArray(block.content)
+            ? block.content.map((b) => b.type === "text" ? b.text : "").filter(Boolean).join("\n")
+            : "";
+        const toolUseId = block.tool_use_id ?? "unknown";
+        return [{
+          role: "tool",
+          content: `[Tool Result for ${toolUseId}]\n${resultText}`
+        }];
+      }
+
+      if (block.text) {
+        return [{ role: message.role, content: block.text }];
+      }
+      return [];
+    });
+  });
+}
+
+function normalizeAnthropicTools(tools) {
+  if (!tools?.length) return null;
+  return tools.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description ?? "",
+      parameters: t.input_schema ?? {}
+    }
+  }));
+}
+
+function normalizeAnthropicToolChoice(toolChoice) {
+  if (!toolChoice) return null;
+  if (toolChoice.type === "none") return "none";
+  if (toolChoice.type === "auto") return "auto";
+  if (toolChoice.type === "any") return "required";
+  if (toolChoice.type === "tool" && toolChoice.name) {
+    return { function: { name: toolChoice.name } };
+  }
+  return "auto";
+}
+
+function resolveAnthropicRequest(body) {
+  const tools = normalizeAnthropicTools(body.tools);
+  const toolChoice = normalizeAnthropicToolChoice(body.tool_choice);
+  const systemPrompt = extractSystemPrompt(body.system);
+  const toolPrompt = (tools?.length && toolChoice !== "none")
+    ? buildToolSystemPrompt(tools, toolChoice)
+    : null;
+
+  const combinedSystem = [systemPrompt, toolPrompt].filter(Boolean).join("\n\n") || null;
+  const messages = normalizeAnthropicMessages(body.messages);
+  const allMessages = combinedSystem
+    ? [{ role: "system", content: combinedSystem }, ...messages]
+    : messages;
+
+  const resolvedModel = resolveOpenAiModel(body.model);
+  const model = tools?.length ? resolveToolCallModel(resolvedModel) : resolvedModel;
+
+  return {
+    model,
+    prompt: buildPromptFromMessages(allMessages, null),
+    tools,
+    modelName: body.model ?? "deepseek-chat-fast"
+  };
+}
+
+function formatAnthropicContent(toolCalls, content, reasoningContent) {
+  const contentBlocks = [];
+
+  if (reasoningContent) {
+    contentBlocks.push({
+      type: "thinking",
+      thinking: reasoningContent,
+      signature: ""
+    });
+  }
+
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      let input;
+      try { input = JSON.parse(tc.function.arguments); } catch { input = {}; }
+      contentBlocks.push({
+        type: "tool_use",
+        id: tc.id,
+        name: tc.function.name,
+        input
+      });
+    }
+  } else {
+    contentBlocks.push({
+      type: "text",
+      text: content
+    });
+  }
+
+  return contentBlocks;
+}
+
+export async function collectAnthropicMessage({ account, body, deleteAfterFinish }) {
+  const requestOptions = resolveAnthropicRequest(body);
+
+  return withCompletionSession({
+    account,
+    body,
+    deleteAfterFinish,
+    onComplete: async (sessionId) => {
+      const { response } = await startCompletion({ account, requestOptions, sessionId });
+      const { content, reasoningContent } = await collectTaggedContent(response.body);
+
+      const toolCalls = requestOptions.tools
+        ? filterToolCalls(extractToolCalls(content), requestOptions.tools)
+        : null;
+
+      const contentBlocks = formatAnthropicContent(toolCalls, content, reasoningContent);
+
+      return {
+        id: `msg_${randomUUID()}`,
+        type: "message",
+        role: "assistant",
+        model: requestOptions.modelName,
+        content: contentBlocks,
+        stop_reason: toolCalls ? "tool_use" : "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 }
+      };
+    }
+  });
+}
+
+function writeSSE(response, eventType, data) {
+  response.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+export async function streamAnthropicMessage({ response, account, body, deleteAfterFinish }) {
+  const messageId = `msg_${randomUUID()}`;
+  const requestOptions = resolveAnthropicRequest(body);
+  const modelName = requestOptions.modelName;
+
+  return withCompletionSession({
+    account,
+    body,
+    deleteAfterFinish,
+    onComplete: async (sessionId) => {
+      const { response: dsResponse } = await startCompletion({ account, requestOptions, sessionId });
+
+      response.writeHead(200, {
+        "cache-control": "no-cache, no-transform",
+        connection: "keep-alive",
+        "content-type": "text/event-stream; charset=utf-8",
+        "x-accel-buffering": "no"
+      });
+      response.flushHeaders?.();
+
+      writeSSE(response, "message_start", {
+        type: "message_start",
+        message: {
+          id: messageId, type: "message", role: "assistant",
+          model: modelName, content: [], stop_reason: null, stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 }
+        }
+      });
+
+      writeSSE(response, "ping", { type: "ping" });
+
+      let blockIndex = 0;
+      let reasoningBlockOpen = false;
+      let textBlockOpen = false;
+      let textAccumulator = "";
+      let reasoningAccumulator = "";
+      let toolCallDetected = false;
+      let toolCallBuffer = "";
+      let hasToolCalls = false;
+
+      function startThinkingBlock() {
+        if (reasoningBlockOpen) return;
+        reasoningBlockOpen = true;
+        writeSSE(response, "content_block_start", {
+          type: "content_block_start",
+          index: blockIndex,
+          content_block: { type: "thinking", thinking: "" }
+        });
+      }
+
+      function closeThinkingBlock() {
+        if (!reasoningBlockOpen) return;
+        reasoningBlockOpen = false;
+        writeSSE(response, "content_block_stop", {
+          type: "content_block_stop", index: blockIndex
+        });
+        blockIndex++;
+      }
+
+      function startTextBlock() {
+        if (textBlockOpen) return;
+        textBlockOpen = true;
+        writeSSE(response, "content_block_start", {
+          type: "content_block_start",
+          index: blockIndex,
+          content_block: { type: "text", text: "" }
+        });
+      }
+
+      function closeTextBlock() {
+        if (!textBlockOpen) return;
+        textBlockOpen = false;
+        writeSSE(response, "content_block_stop", {
+          type: "content_block_stop", index: blockIndex
+        });
+        blockIndex++;
+      }
+
+      if (requestOptions.tools) {
+        await consumeTaggedStream(dsResponse.body, (tagged) => {
+          if (tagged.kind === "thinking") {
+            startThinkingBlock();
+            writeSSE(response, "content_block_delta", {
+              type: "content_block_delta",
+              index: blockIndex,
+              delta: { type: "thinking_delta", thinking: tagged.text }
+            });
+            reasoningAccumulator += tagged.text;
+            return;
+          }
+
+          const text = tagged.text;
+          if (toolCallDetected) {
+            toolCallBuffer += text;
+            return;
+          }
+
+          textAccumulator += text;
+          const markerIndex = findToolCallMarker(textAccumulator);
+          if (markerIndex !== -1) {
+            toolCallDetected = true;
+            toolCallBuffer = textAccumulator.slice(markerIndex);
+            const before = textAccumulator.slice(0, markerIndex);
+            textAccumulator = "";
+            if (before) {
+              startTextBlock();
+              writeSSE(response, "content_block_delta", {
+                type: "content_block_delta",
+                index: blockIndex,
+                delta: { type: "text_delta", text: before }
+              });
+            }
+            return;
+          }
+
+          let safeEnd = textAccumulator.length;
+          if (isPartialMarker(textAccumulator)) {
+            for (let i = Math.max(0, textAccumulator.length - 20); i < textAccumulator.length; i++) {
+              if (textAccumulator[i] !== "<" && textAccumulator[i] !== "`") continue;
+              const tail = textAccumulator.slice(i);
+              let isPartial = false;
+              for (const marker of TOOL_CALL_MARKERS) {
+                if (marker.startsWith(tail)) { isPartial = true; break; }
+              }
+              if (tail.startsWith("```")) { isPartial = true; }
+              if (isPartial) { safeEnd = i; break; }
+            }
+          }
+          const toStream = textAccumulator.slice(0, safeEnd);
+          textAccumulator = textAccumulator.slice(safeEnd);
+
+          if (toStream) {
+            startTextBlock();
+            writeSSE(response, "content_block_delta", {
+              type: "content_block_delta",
+              index: blockIndex,
+              delta: { type: "text_delta", text: toStream }
+            });
+          }
+        });
+
+        if (textAccumulator && !toolCallDetected) {
+          startTextBlock();
+          writeSSE(response, "content_block_delta", {
+            type: "content_block_delta",
+            index: blockIndex,
+            delta: { type: "text_delta", text: textAccumulator }
+          });
+          textAccumulator = "";
+        }
+
+        closeThinkingBlock();
+        closeTextBlock();
+
+        if (toolCallDetected) {
+          const toolCalls = filterToolCalls(extractToolCalls(toolCallBuffer), requestOptions.tools);
+          if (toolCalls) {
+            hasToolCalls = true;
+            for (const tc of toolCalls) {
+              let input;
+              try { input = JSON.parse(tc.function.arguments); } catch { input = {}; }
+
+              writeSSE(response, "content_block_start", {
+                type: "content_block_start",
+                index: blockIndex,
+                content_block: { type: "tool_use", id: tc.id, name: tc.function.name, input: {} }
+              });
+              writeSSE(response, "content_block_delta", {
+                type: "content_block_delta",
+                index: blockIndex,
+                delta: { type: "input_json_delta", partial_json: tc.function.arguments }
+              });
+              writeSSE(response, "content_block_stop", {
+                type: "content_block_stop", index: blockIndex
+              });
+              blockIndex++;
+            }
+          } else {
+            startTextBlock();
+            writeSSE(response, "content_block_delta", {
+              type: "content_block_delta",
+              index: blockIndex,
+              delta: { type: "text_delta", text: toolCallBuffer }
+            });
+            closeTextBlock();
+          }
+        }
+      } else {
+        await consumeTaggedStream(dsResponse.body, (tagged) => {
+          if (tagged.kind === "thinking") {
+            startThinkingBlock();
+            writeSSE(response, "content_block_delta", {
+              type: "content_block_delta",
+              index: blockIndex,
+              delta: { type: "thinking_delta", thinking: tagged.text }
+            });
+            reasoningAccumulator += tagged.text;
+            return;
+          }
+
+          startTextBlock();
+          writeSSE(response, "content_block_delta", {
+            type: "content_block_delta",
+            index: blockIndex,
+            delta: { type: "text_delta", text: tagged.text }
+          });
+          textAccumulator += tagged.text;
+        });
+
+        closeThinkingBlock();
+        closeTextBlock();
+      }
+
+      writeSSE(response, "message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
+        usage: { output_tokens: 0 }
+      });
+      writeSSE(response, "message_stop", { type: "message_stop" });
+
+      response.end();
+    }
+  });
+}

--- a/src/services/anthropic-bridge.js
+++ b/src/services/anthropic-bridge.js
@@ -224,7 +224,6 @@ export async function streamAnthropicMessage({ response, account, body, deleteAf
       let reasoningBlockOpen = false;
       let textBlockOpen = false;
       let textAccumulator = "";
-      let reasoningAccumulator = "";
       let toolCallDetected = false;
       let toolCallBuffer = "";
       let hasToolCalls = false;
@@ -276,7 +275,6 @@ export async function streamAnthropicMessage({ response, account, body, deleteAf
               index: blockIndex,
               delta: { type: "thinking_delta", thinking: tagged.text }
             });
-            reasoningAccumulator += tagged.text;
             return;
           }
 
@@ -388,7 +386,6 @@ export async function streamAnthropicMessage({ response, account, body, deleteAf
               index: blockIndex,
               delta: { type: "thinking_delta", thinking: tagged.text }
             });
-            reasoningAccumulator += tagged.text;
             return;
           }
 

--- a/src/services/completion-core.js
+++ b/src/services/completion-core.js
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+
+import { createDeepseekDeltaDecoder, createSseParser } from "../utils/deepseek-sse.js";
+import { createChatSession, deleteChatSession } from "./chat-session-service.js";
+import { proxyDeepseekRequest } from "./deepseek-proxy.js";
+
+export const TOOL_CALL_MARKERS = ["<tool_call", "<function_call"];
+
+export function findToolCallMarker(text) {
+  let earliest = -1;
+  for (const marker of TOOL_CALL_MARKERS) {
+    const idx = text.indexOf(marker);
+    if (idx !== -1 && (earliest === -1 || idx < earliest)) {
+      earliest = idx;
+    }
+  }
+  return earliest;
+}
+
+export function isPartialMarker(text) {
+  for (const marker of TOOL_CALL_MARKERS) {
+    for (let i = Math.max(0, text.length - marker.length); i < text.length; i++) {
+      if (text[i] !== "<") continue;
+      const tail = text.slice(i);
+      if (marker.startsWith(tail)) return true;
+    }
+  }
+  return false;
+}
+
+export function filterToolCalls(toolCalls, tools) {
+  if (!toolCalls || !tools) return null;
+
+  const validNames = tools.map((t) => t.function?.name).filter(Boolean);
+
+  const filtered = toolCalls.map((tc) => {
+    if (validNames.includes(tc.function.name)) return tc;
+
+    const tcLower = tc.function.name.toLowerCase().replace(/-/g, "_");
+    const match = validNames.find((name) => {
+      const nameLower = name.toLowerCase().replace(/-/g, "_");
+      return nameLower === tcLower
+        || name.endsWith("__" + tc.function.name)
+        || name.endsWith("." + tc.function.name);
+    });
+    if (match) return { ...tc, function: { ...tc.function, name: match } };
+
+    return null;
+  }).filter(Boolean);
+
+  return filtered.length > 0 ? filtered : null;
+}
+
+export async function startCompletion({ account, requestOptions, sessionId }) {
+  return proxyDeepseekRequest({
+    account,
+    method: "POST",
+    path: "/api/v0/chat/completion",
+    body: Buffer.from(
+      JSON.stringify({
+        chat_session_id: sessionId,
+        parent_message_id: null,
+        model_type: requestOptions.model.modelType,
+        prompt: requestOptions.prompt,
+        ref_file_ids: [],
+        thinking_enabled: requestOptions.model.thinkingEnabled,
+        search_enabled: requestOptions.model.searchEnabled,
+        preempt: false
+      })
+    ),
+    headers: { "content-type": "application/json" }
+  });
+}
+
+export async function consumeTaggedStream(stream, onTagged) {
+  if (!stream) {
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  const deltaDecoder = createDeepseekDeltaDecoder();
+  const parser = createSseParser(({ data }) => {
+    const delta = deltaDecoder.consume(data);
+    if (delta?.text) {
+      onTagged({ kind: delta.kind, text: delta.text });
+    }
+  });
+
+  for await (const chunk of stream) {
+    parser.push(decoder.decode(chunk, { stream: true }));
+  }
+  parser.flush();
+}
+
+export async function collectTaggedContent(stream) {
+  let content = "";
+  let reasoningContent = "";
+
+  await consumeTaggedStream(stream, (tagged) => {
+    if (tagged.kind === "thinking") {
+      reasoningContent += tagged.text;
+    } else {
+      content += tagged.text;
+    }
+  });
+
+  return { content, reasoningContent };
+}
+
+export async function withCompletionSession({ account, body, deleteAfterFinish, onComplete }) {
+  const sessionId = await createChatSession(account);
+
+  try {
+    return await onComplete(sessionId);
+  } finally {
+    if (deleteAfterFinish) {
+      await deleteChatSession(account, sessionId);
+    }
+  }
+}

--- a/src/services/openai-bridge.js
+++ b/src/services/openai-bridge.js
@@ -1,10 +1,17 @@
 import { randomUUID } from "node:crypto";
 
-import { createDeepseekDeltaDecoder, createSseParser } from "../utils/deepseek-sse.js";
 import { buildPromptFromMessages } from "../utils/prompt.js";
 import { buildToolSystemPrompt, extractToolCalls } from "../utils/tool-prompt.js";
-import { createChatSession, deleteChatSession } from "./chat-session-service.js";
-import { proxyDeepseekRequest } from "./deepseek-proxy.js";
+import {
+  collectTaggedContent,
+  consumeTaggedStream,
+  filterToolCalls,
+  findToolCallMarker,
+  isPartialMarker,
+  startCompletion,
+  TOOL_CALL_MARKERS,
+  withCompletionSession
+} from "./completion-core.js";
 import { assertNoLegacySearchOptions, resolveOpenAiModel, resolveToolCallModel } from "./openai-request.js";
 
 function toContentText(content) {
@@ -48,30 +55,6 @@ function normalizeMessages(messages) {
   });
 }
 
-function filterToolCalls(toolCalls, tools) {
-  if (!toolCalls || !tools) return null;
-
-  const validNames = tools.map((t) => t.function?.name).filter(Boolean);
-
-  const filtered = toolCalls.map((tc) => {
-    if (validNames.includes(tc.function.name)) return tc;
-
-    // Fuzzy: case-insensitive, underscore/hyphen interchange
-    const tcLower = tc.function.name.toLowerCase().replace(/-/g, "_");
-    const match = validNames.find((name) => {
-      const nameLower = name.toLowerCase().replace(/-/g, "_");
-      return nameLower === tcLower
-        || name.endsWith("__" + tc.function.name)
-        || name.endsWith("." + tc.function.name);
-    });
-    if (match) return { ...tc, function: { ...tc.function, name: match } };
-
-    return null;
-  }).filter(Boolean);
-
-  return filtered.length > 0 ? filtered : null;
-}
-
 function resolveCompletionRequest(body) {
   assertNoLegacySearchOptions(body);
 
@@ -91,47 +74,6 @@ function resolveCompletionRequest(body) {
   };
 }
 
-async function startCompletion({ account, requestOptions, sessionId }) {
-  return proxyDeepseekRequest({
-    account,
-    method: "POST",
-    path: "/api/v0/chat/completion",
-    body: Buffer.from(
-      JSON.stringify({
-        chat_session_id: sessionId,
-        parent_message_id: null,
-        model_type: requestOptions.model.modelType,
-        prompt: requestOptions.prompt,
-        ref_file_ids: [],
-        thinking_enabled: requestOptions.model.thinkingEnabled,
-        search_enabled: requestOptions.model.searchEnabled,
-        preempt: false
-      })
-    ),
-    headers: { "content-type": "application/json" }
-  });
-}
-
-async function consumeTaggedStream(stream, onTagged) {
-  if (!stream) {
-    return;
-  }
-
-  const decoder = new TextDecoder();
-  const deltaDecoder = createDeepseekDeltaDecoder();
-  const parser = createSseParser(({ data }) => {
-    const delta = deltaDecoder.consume(data);
-    if (delta?.text) {
-      onTagged({ kind: delta.kind, text: delta.text });
-    }
-  });
-
-  for await (const chunk of stream) {
-    parser.push(decoder.decode(chunk, { stream: true }));
-  }
-  parser.flush();
-}
-
 function buildChunkPayload(completionId, model, delta, finishReason) {
   const choice = finishReason
     ? { index: 0, delta: {}, finish_reason: finishReason }
@@ -146,18 +88,6 @@ function buildChunkPayload(completionId, model, delta, finishReason) {
   };
 }
 
-async function withCompletionSession({ account, body, deleteAfterFinish, onComplete }) {
-  const sessionId = await createChatSession(account);
-
-  try {
-    return await onComplete(sessionId);
-  } finally {
-    if (deleteAfterFinish) {
-      await deleteChatSession(account, sessionId);
-    }
-  }
-}
-
 export async function collectOpenAiResponse({ account, body, deleteAfterFinish = false }) {
   const requestOptions = resolveCompletionRequest(body);
 
@@ -167,16 +97,7 @@ export async function collectOpenAiResponse({ account, body, deleteAfterFinish =
     deleteAfterFinish,
     onComplete: async (sessionId) => {
       const { response } = await startCompletion({ account, requestOptions, sessionId });
-      let content = "";
-      let reasoningContent = "";
-
-      await consumeTaggedStream(response.body, (tagged) => {
-        if (tagged.kind === "thinking") {
-          reasoningContent += tagged.text;
-        } else {
-          content += tagged.text;
-        }
-      });
+      const { content, reasoningContent } = await collectTaggedContent(response.body);
 
       const toolCalls = requestOptions.tools ? filterToolCalls(extractToolCalls(content), requestOptions.tools) : null;
 
@@ -235,30 +156,6 @@ function buildToolCallChunkPayload(completionId, model, toolCalls, finishReason)
     model,
     choices: [choice]
   };
-}
-
-const TOOL_CALL_MARKERS = ["<tool_call", "<function_call"];
-
-function findToolCallMarker(text) {
-  let earliest = -1;
-  for (const marker of TOOL_CALL_MARKERS) {
-    const idx = text.indexOf(marker);
-    if (idx !== -1 && (earliest === -1 || idx < earliest)) {
-      earliest = idx;
-    }
-  }
-  return earliest;
-}
-
-function isPartialMarker(text) {
-  for (const marker of TOOL_CALL_MARKERS) {
-    for (let i = Math.max(0, text.length - marker.length); i < text.length; i++) {
-      if (text[i] !== "<") continue;
-      const tail = text.slice(i);
-      if (marker.startsWith(tail)) return true;
-    }
-  }
-  return false;
 }
 
 export async function streamOpenAiResponse(options) {
@@ -329,7 +226,6 @@ export async function streamOpenAiResponse(options) {
             return;
           }
 
-          // Safe streaming: hold back partial marker prefixes
           let safeEnd = textBuffer.length;
           if (isPartialMarker(textBuffer)) {
             for (let i = Math.max(0, textBuffer.length - 20); i < textBuffer.length; i++) {

--- a/src/services/openai-request.js
+++ b/src/services/openai-request.js
@@ -7,7 +7,11 @@ const BASE_OPENAI_MODELS = Object.freeze([
   Object.freeze({ id: "deepseek-chat-fast", modelType: "default", thinkingEnabled: false }),
   Object.freeze({ id: "deepseek-reasoner-fast", modelType: "default", thinkingEnabled: true }),
   Object.freeze({ id: "deepseek-chat-expert", modelType: "expert", thinkingEnabled: false }),
-  Object.freeze({ id: "deepseek-reasoner-expert", modelType: "expert", thinkingEnabled: true })
+  Object.freeze({ id: "deepseek-reasoner-expert", modelType: "expert", thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-flash", modelType: "default", thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-reasoner-flash", modelType: "default", thinkingEnabled: true }),
+  Object.freeze({ id: "deepseek-v4-pro", modelType: "expert", thinkingEnabled: false }),
+  Object.freeze({ id: "deepseek-v4-reasoner-pro", modelType: "expert", thinkingEnabled: true })
 ]);
 
 function createModelVariant(baseModel, searchEnabled) {

--- a/src/services/responses-bridge.js
+++ b/src/services/responses-bridge.js
@@ -80,13 +80,18 @@ function normalizeResponsesTools(tools) {
       function: {
         name: t.name,
         description: t.description ?? "",
-        parameters: t.parameters ?? {}
+        parameters: t.parameters ?? t.input_schema ?? t.inputSchema ?? {}
       }
     }));
 }
 
 function normalizeResponsesToolChoice(toolChoice, tools) {
-  if (!tools?.length) return null;
+  if (!tools?.length) {
+    if (toolChoice && toolChoice !== "none") {
+      console.warn("[responses-bridge] tool_choice '%s' specified but no tools provided; ignoring tool_choice", toolChoice?.type ? toolChoice.type : toolChoice);
+    }
+    return null;
+  }
   if (!toolChoice || toolChoice === "auto") return "auto";
   if (toolChoice === "none") return "none";
   if (toolChoice === "required") return "required";
@@ -103,13 +108,24 @@ function resolveResponsesRequest(body) {
     ? buildToolSystemPrompt(tools, toolChoice)
     : null;
 
-  const messages = normalizeResponsesInput(body.input, body.instructions);
+  const instructions = [body.instructions, toolPrompt].filter(Boolean).join("\n\n") || undefined;
+  const input = body.input ?? body.messages;
+  const messages = normalizeResponsesInput(input, instructions);
   const resolvedModel = resolveOpenAiModel(body.model);
   const model = tools?.length ? resolveToolCallModel(resolvedModel) : resolvedModel;
 
+  if (process.env.DEBUG_TOOL_CALL) {
+    console.log("[responses-bridge] model:", body.model, "-> resolved:", resolvedModel.id,
+      "| tools:", tools?.length, "| toolChoice:", toolChoice,
+      "| input type:", Array.isArray(input) ? "array" : typeof input,
+      "| input length:", Array.isArray(input) ? input.length : (typeof input === "string" ? input.length : 0),
+      "| toolPrompt:", toolPrompt ? `${toolPrompt.length} chars` : "null");
+    console.log("[responses-bridge] prompt:\n", buildPromptFromMessages(messages, null));
+  }
+
   return {
     model,
-    prompt: buildPromptFromMessages(messages, toolPrompt),
+    prompt: buildPromptFromMessages(messages, null),
     tools
   };
 }
@@ -224,6 +240,35 @@ function emitResponseTextChunk(writeSSE, outIdx, text, state) {
   state.emittedText += text;
 }
 
+function emitReasoningDone(writeSSE, state) {
+  if (!state.reasoningItemId) return;
+  writeSSE("response.reasoning_text.done", {
+    item_id: state.reasoningItemId,
+    output_index: 0, text: state.reasoningAccumulator
+  });
+  writeSSE("response.output_item.done", {
+    output_index: 0,
+    item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
+  });
+}
+
+function emitMessageDone(writeSSE, state, text, outIdx) {
+  if (!state.messageItemId) return;
+  writeSSE("response.output_text.done", {
+    item_id: state.messageItemId,
+    output_index: outIdx, content_index: 0, text
+  });
+  writeSSE("response.content_part.done", {
+    item_id: state.messageItemId,
+    output_index: outIdx, content_index: 0,
+    part: { type: "output_text", text }
+  });
+  writeSSE("response.output_item.done", {
+    output_index: outIdx,
+    item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text }] }
+  });
+}
+
 export async function streamResponsesResult({ response, account, body, deleteAfterFinish }) {
   const responseId = `resp_${randomUUID()}`;
   const requestOptions = resolveResponsesRequest(body);
@@ -263,7 +308,8 @@ export async function streamResponsesResult({ response, account, body, deleteAft
         emittedText: "",
         reasoningAccumulator: "",
         toolCallDetected: false,
-        toolCallBuffer: ""
+        toolCallBuffer: "",
+        toolCalls: null
       };
 
       const textOutputBaseIdx = () => state.reasoningItemId ? 1 : 0;
@@ -330,36 +376,12 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           state.textAccumulator = "";
         }
 
-        if (state.reasoningItemId) {
-          writeSSE("response.reasoning_text.done", {
-            item_id: state.reasoningItemId,
-            output_index: 0, text: state.reasoningAccumulator
-          });
-          writeSSE("response.output_item.done", {
-            output_index: 0,
-            item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
-          });
-        }
-
-        if (state.messageItemId) {
-          const outIdx = textOutputBaseIdx();
-          writeSSE("response.output_text.done", {
-            item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0, text: state.emittedText
-          });
-          writeSSE("response.content_part.done", {
-            item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0,
-            part: { type: "output_text", text: state.emittedText }
-          });
-          writeSSE("response.output_item.done", {
-            output_index: outIdx,
-            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.emittedText }] }
-          });
-        }
+        emitReasoningDone(writeSSE, state);
+        emitMessageDone(writeSSE, state, state.emittedText, textOutputBaseIdx());
 
         if (state.toolCallDetected) {
           const toolCalls = filterToolCalls(extractToolCalls(state.toolCallBuffer), requestOptions.tools);
+          state.toolCalls = toolCalls;
           if (toolCalls) {
             let fcIdx = textOutputBaseIdx() + (state.messageItemId ? 1 : 0);
             for (const tc of toolCalls) {
@@ -382,22 +404,7 @@ export async function streamResponsesResult({ response, account, body, deleteAft
             }
           } else {
             emitTextChunk(state.toolCallBuffer);
-            if (state.messageItemId) {
-              const outIdx = textOutputBaseIdx();
-              writeSSE("response.output_text.done", {
-                item_id: state.messageItemId,
-                output_index: outIdx, content_index: 0, text: state.toolCallBuffer
-              });
-              writeSSE("response.content_part.done", {
-                item_id: state.messageItemId,
-                output_index: outIdx, content_index: 0,
-                part: { type: "output_text", text: state.toolCallBuffer }
-              });
-              writeSSE("response.output_item.done", {
-                output_index: outIdx,
-                item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.toolCallBuffer }] }
-              });
-            }
+            emitMessageDone(writeSSE, state, state.toolCallBuffer, textOutputBaseIdx());
           }
         }
       } else {
@@ -438,38 +445,18 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           state.emittedText += tagged.text;
         });
 
-        if (state.reasoningItemId) {
-          writeSSE("response.reasoning_text.done", {
-            item_id: state.reasoningItemId,
-            output_index: 0, text: state.reasoningAccumulator
-          });
-          writeSSE("response.output_item.done", {
-            output_index: 0,
-            item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
-          });
-        }
-
-        if (state.messageItemId) {
-          const outIdx = textOutputBaseIdx();
-          writeSSE("response.output_text.done", {
-            item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0, text: state.emittedText
-          });
-          writeSSE("response.content_part.done", {
-            item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0,
-            part: { type: "output_text", text: state.emittedText }
-          });
-          writeSSE("response.output_item.done", {
-            output_index: outIdx,
-            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.emittedText }] }
-          });
-        }
+        emitReasoningDone(writeSSE, state);
+        emitMessageDone(writeSSE, state, state.emittedText, textOutputBaseIdx());
       }
 
       const output = [];
       if (state.reasoningAccumulator) {
         output.push(formatReasoningItem(state.reasoningAccumulator));
+      }
+      if (state.toolCalls) {
+        for (const tc of state.toolCalls) {
+          output.push(formatFunctionCallItem(tc));
+        }
       }
       if (state.messageItemId) {
         output.push(formatMessageItem(state.emittedText));

--- a/src/services/responses-bridge.js
+++ b/src/services/responses-bridge.js
@@ -221,7 +221,7 @@ function emitResponseTextChunk(writeSSE, outIdx, text, state) {
     content_index: 0,
     delta: text
   });
-  state.textAccumulator += text;
+  state.emittedText += text;
 }
 
 export async function streamResponsesResult({ response, account, body, deleteAfterFinish }) {
@@ -260,6 +260,7 @@ export async function streamResponsesResult({ response, account, body, deleteAft
         reasoningItemId: null,
         messageItemId: null,
         textAccumulator: "",
+        emittedText: "",
         reasoningAccumulator: "",
         toolCallDetected: false,
         toolCallBuffer: ""
@@ -344,16 +345,16 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           const outIdx = textOutputBaseIdx();
           writeSSE("response.output_text.done", {
             item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0, text: state.textAccumulator
+            output_index: outIdx, content_index: 0, text: state.emittedText
           });
           writeSSE("response.content_part.done", {
             item_id: state.messageItemId,
             output_index: outIdx, content_index: 0,
-            part: { type: "output_text", text: state.textAccumulator }
+            part: { type: "output_text", text: state.emittedText }
           });
           writeSSE("response.output_item.done", {
             output_index: outIdx,
-            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
+            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.emittedText }] }
           });
         }
 
@@ -434,7 +435,7 @@ export async function streamResponsesResult({ response, account, body, deleteAft
             item_id: state.messageItemId,
             output_index: outIdx, content_index: 0, delta: tagged.text
           });
-          state.textAccumulator += tagged.text;
+          state.emittedText += tagged.text;
         });
 
         if (state.reasoningItemId) {
@@ -452,25 +453,33 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           const outIdx = textOutputBaseIdx();
           writeSSE("response.output_text.done", {
             item_id: state.messageItemId,
-            output_index: outIdx, content_index: 0, text: state.textAccumulator
+            output_index: outIdx, content_index: 0, text: state.emittedText
           });
           writeSSE("response.content_part.done", {
             item_id: state.messageItemId,
             output_index: outIdx, content_index: 0,
-            part: { type: "output_text", text: state.textAccumulator }
+            part: { type: "output_text", text: state.emittedText }
           });
           writeSSE("response.output_item.done", {
             output_index: outIdx,
-            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
+            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.emittedText }] }
           });
         }
+      }
+
+      const output = [];
+      if (state.reasoningAccumulator) {
+        output.push(formatReasoningItem(state.reasoningAccumulator));
+      }
+      if (state.messageItemId) {
+        output.push(formatMessageItem(state.emittedText));
       }
 
       writeSSE("response.completed", {
         response: {
           id: responseId, object: "response", created_at: created,
           status: "completed", completed_at: Math.floor(Date.now() / 1000),
-          model: modelId, output: [],
+          model: modelId, output,
           usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
         }
       });

--- a/src/services/responses-bridge.js
+++ b/src/services/responses-bridge.js
@@ -1,0 +1,458 @@
+import { randomUUID } from "node:crypto";
+
+import { buildPromptFromMessages } from "../utils/prompt.js";
+import { buildToolSystemPrompt, extractToolCalls } from "../utils/tool-prompt.js";
+import {
+  collectTaggedContent,
+  consumeTaggedStream,
+  filterToolCalls,
+  findToolCallMarker,
+  isPartialMarker,
+  startCompletion,
+  TOOL_CALL_MARKERS,
+  withCompletionSession
+} from "./completion-core.js";
+import { resolveOpenAiModel, resolveToolCallModel } from "./openai-request.js";
+
+function toContentText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((item) => {
+      if (item?.type === "output_text") return item.text ?? "";
+      if (item?.type === "input_text") return item.text ?? "";
+      if (item?.type === "text") return item.text ?? "";
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function normalizeResponsesInput(input, instructions) {
+  const messages = [];
+
+  if (instructions) {
+    messages.push({ role: "system", content: instructions });
+  }
+
+  const items = typeof input === "string"
+    ? [{ role: "user", content: input }]
+    : Array.isArray(input) ? input : [];
+
+  for (const item of items) {
+    if (item.type === "message" && item.role) {
+      const role = item.role === "developer" ? "system" : item.role;
+      messages.push({ role, content: toContentText(item.content) });
+      continue;
+    }
+
+    if (item.role) {
+      const role = item.role === "developer" ? "system" : item.role;
+      messages.push({ role, content: toContentText(item.content) });
+      continue;
+    }
+
+    if (item.type === "function_call") {
+      messages.push({
+        role: "assistant",
+        content: `[Called tool: ${item.name}]\n<tool_call={"name": "${item.name}", "arguments": ${item.arguments ?? "{}"}}`
+      });
+      continue;
+    }
+
+    if (item.type === "function_call_output") {
+      messages.push({
+        role: "tool",
+        content: `[Tool Result for call ${item.call_id ?? "unknown"}]\n${typeof item.output === "string" ? item.output : JSON.stringify(item.output)}`
+      });
+    }
+  }
+
+  return messages;
+}
+
+function normalizeResponsesTools(tools) {
+  if (!tools?.length) return null;
+  return tools
+    .filter((t) => t.type === "function")
+    .map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description ?? "",
+        parameters: t.parameters ?? {}
+      }
+    }));
+}
+
+function normalizeResponsesToolChoice(toolChoice, tools) {
+  if (!tools?.length) return null;
+  if (!toolChoice || toolChoice === "auto") return "auto";
+  if (toolChoice === "none") return "none";
+  if (toolChoice === "required") return "required";
+  if (toolChoice.type === "function" && toolChoice.name) {
+    return { function: { name: toolChoice.name } };
+  }
+  return "auto";
+}
+
+function resolveResponsesRequest(body) {
+  const tools = normalizeResponsesTools(body.tools);
+  const toolChoice = normalizeResponsesToolChoice(body.tool_choice, tools);
+  const toolPrompt = (tools?.length && toolChoice !== "none")
+    ? buildToolSystemPrompt(tools, toolChoice)
+    : null;
+
+  const messages = normalizeResponsesInput(body.input, body.instructions);
+  const resolvedModel = resolveOpenAiModel(body.model);
+  const model = tools?.length ? resolveToolCallModel(resolvedModel) : resolvedModel;
+
+  return {
+    model,
+    prompt: buildPromptFromMessages(messages, toolPrompt),
+    tools
+  };
+}
+
+function formatReasoningItem(reasoningContent) {
+  return {
+    type: "reasoning",
+    id: `rs_${randomUUID()}`,
+    summary: [{ type: "summary_text", text: reasoningContent }]
+  };
+}
+
+function formatMessageItem(content) {
+  return {
+    type: "message",
+    id: `msg_${randomUUID()}`,
+    role: "assistant",
+    content: [{ type: "output_text", text: content }],
+    status: "completed"
+  };
+}
+
+function formatFunctionCallItem(tc) {
+  return {
+    type: "function_call",
+    id: `fc_${randomUUID()}`,
+    call_id: tc.id,
+    name: tc.function.name,
+    arguments: tc.function.arguments,
+    status: "completed"
+  };
+}
+
+function buildResponsesOutput(toolCalls, content, reasoningContent) {
+  const output = [];
+
+  if (reasoningContent) {
+    output.push(formatReasoningItem(reasoningContent));
+  }
+
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      output.push(formatFunctionCallItem(tc));
+    }
+  } else {
+    output.push(formatMessageItem(content));
+  }
+
+  return output;
+}
+
+export async function collectResponsesResult({ account, body, deleteAfterFinish }) {
+  const requestOptions = resolveResponsesRequest(body);
+
+  return withCompletionSession({
+    account,
+    body,
+    deleteAfterFinish,
+    onComplete: async (sessionId) => {
+      const { response } = await startCompletion({ account, requestOptions, sessionId });
+      const { content, reasoningContent } = await collectTaggedContent(response.body);
+
+      const toolCalls = requestOptions.tools
+        ? filterToolCalls(extractToolCalls(content), requestOptions.tools)
+        : null;
+
+      const output = buildResponsesOutput(toolCalls, content, reasoningContent);
+      const now = Math.floor(Date.now() / 1000);
+
+      return {
+        id: `resp_${randomUUID()}`,
+        object: "response",
+        created_at: now,
+        status: "completed",
+        completed_at: now,
+        model: requestOptions.model.id,
+        output,
+        usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+      };
+    }
+  });
+}
+
+function writeSSE(response, event, data) {
+  response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function emitResponseTextChunk(response, outIdx, text, state) {
+  if (!state.messageItemId) {
+    state.messageItemId = `msg_${randomUUID()}`;
+    writeSSE(response, "response.output_item.added", {
+      output_index: outIdx,
+      item: { id: state.messageItemId, type: "message", role: "assistant", content: [] }
+    });
+    writeSSE(response, "response.content_part.added", {
+      output_index: outIdx,
+      content_index: 0,
+      part: { type: "output_text", text: "" }
+    });
+  }
+  writeSSE(response, "response.output_text.delta", {
+    output_index: outIdx,
+    content_index: 0,
+    delta: text
+  });
+  state.textAccumulator += text;
+}
+
+export async function streamResponsesResult({ response, account, body, deleteAfterFinish }) {
+  const responseId = `resp_${randomUUID()}`;
+  const requestOptions = resolveResponsesRequest(body);
+  const modelId = requestOptions.model.id;
+  const created = Math.floor(Date.now() / 1000);
+
+  return withCompletionSession({
+    account,
+    body,
+    deleteAfterFinish,
+    onComplete: async (sessionId) => {
+      const { response: dsResponse } = await startCompletion({ account, requestOptions, sessionId });
+
+      response.writeHead(200, {
+        "cache-control": "no-cache, no-transform",
+        connection: "keep-alive",
+        "content-type": "text/event-stream; charset=utf-8",
+        "x-accel-buffering": "no"
+      });
+      response.flushHeaders?.();
+
+      const baseResponse = {
+        id: responseId, object: "response", created_at: created,
+        status: "in_progress", model: modelId, output: [],
+        usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+      };
+      writeSSE(response, "response.created", baseResponse);
+      writeSSE(response, "response.in_progress", baseResponse);
+
+      const state = {
+        reasoningItemId: null,
+        messageItemId: null,
+        textAccumulator: "",
+        reasoningAccumulator: "",
+        toolCallDetected: false,
+        toolCallBuffer: ""
+      };
+
+      const textOutputBaseIdx = () => state.reasoningItemId ? 1 : 0;
+
+      function emitTextChunk(text) {
+        emitResponseTextChunk(response, textOutputBaseIdx(), text, state);
+      }
+
+      if (requestOptions.tools) {
+        await consumeTaggedStream(dsResponse.body, (tagged) => {
+          if (tagged.kind === "thinking") {
+            if (!state.reasoningItemId) {
+              state.reasoningItemId = `rs_${randomUUID()}`;
+              writeSSE(response, "response.output_item.added", {
+                output_index: 0,
+                item: { type: "reasoning", id: state.reasoningItemId, summary: [] }
+              });
+            }
+            writeSSE(response, "response.reasoning_text.delta", {
+              output_index: 0, delta: tagged.text
+            });
+            state.reasoningAccumulator += tagged.text;
+            return;
+          }
+
+          const text = tagged.text;
+          if (state.toolCallDetected) {
+            state.toolCallBuffer += text;
+            return;
+          }
+
+          state.textAccumulator += text;
+          const markerIndex = findToolCallMarker(state.textAccumulator);
+          if (markerIndex !== -1) {
+            state.toolCallDetected = true;
+            state.toolCallBuffer = state.textAccumulator.slice(markerIndex);
+            const before = state.textAccumulator.slice(0, markerIndex);
+            state.textAccumulator = "";
+            if (before) emitTextChunk(before);
+            return;
+          }
+
+          let safeEnd = state.textAccumulator.length;
+          if (isPartialMarker(state.textAccumulator)) {
+            for (let i = Math.max(0, state.textAccumulator.length - 20); i < state.textAccumulator.length; i++) {
+              if (state.textAccumulator[i] !== "<" && state.textAccumulator[i] !== "`") continue;
+              const tail = state.textAccumulator.slice(i);
+              let isPartial = false;
+              for (const marker of TOOL_CALL_MARKERS) {
+                if (marker.startsWith(tail)) { isPartial = true; break; }
+              }
+              if (tail.startsWith("```")) { isPartial = true; }
+              if (isPartial) { safeEnd = i; break; }
+            }
+          }
+          const toStream = state.textAccumulator.slice(0, safeEnd);
+          state.textAccumulator = state.textAccumulator.slice(safeEnd);
+          if (toStream) emitTextChunk(toStream);
+        });
+
+        if (state.textAccumulator && !state.toolCallDetected) {
+          emitTextChunk(state.textAccumulator);
+          state.textAccumulator = "";
+        }
+
+        if (state.reasoningItemId) {
+          writeSSE(response, "response.reasoning_text.done", {
+            output_index: 0, text: state.reasoningAccumulator
+          });
+          writeSSE(response, "response.output_item.done", {
+            output_index: 0,
+            item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
+          });
+        }
+
+        if (state.messageItemId) {
+          const outIdx = textOutputBaseIdx();
+          writeSSE(response, "response.output_text.done", {
+            output_index: outIdx, content_index: 0, text: state.textAccumulator
+          });
+          writeSSE(response, "response.content_part.done", {
+            output_index: outIdx, content_index: 0,
+            part: { type: "output_text", text: state.textAccumulator }
+          });
+          writeSSE(response, "response.output_item.done", {
+            output_index: outIdx,
+            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
+          });
+        }
+
+        if (state.toolCallDetected) {
+          const toolCalls = filterToolCalls(extractToolCalls(state.toolCallBuffer), requestOptions.tools);
+          if (toolCalls) {
+            let fcIdx = textOutputBaseIdx() + (state.messageItemId ? 1 : 0);
+            for (const tc of toolCalls) {
+              const fcId = `fc_${randomUUID()}`;
+              writeSSE(response, "response.output_item.added", {
+                output_index: fcIdx,
+                item: { type: "function_call", id: fcId, call_id: tc.id, name: tc.function.name }
+              });
+              writeSSE(response, "response.function_call_arguments.delta", {
+                output_index: fcIdx, item_id: fcId, delta: tc.function.arguments
+              });
+              writeSSE(response, "response.function_call_arguments.done", {
+                output_index: fcIdx, item_id: fcId, arguments: tc.function.arguments
+              });
+              writeSSE(response, "response.output_item.done", {
+                output_index: fcIdx,
+                item: { type: "function_call", id: fcId, call_id: tc.id, name: tc.function.name, arguments: tc.function.arguments }
+              });
+              fcIdx++;
+            }
+          } else {
+            emitTextChunk(state.toolCallBuffer);
+            if (state.messageItemId) {
+              const outIdx = textOutputBaseIdx();
+              writeSSE(response, "response.output_text.done", {
+                output_index: outIdx, content_index: 0, text: state.toolCallBuffer
+              });
+              writeSSE(response, "response.content_part.done", {
+                output_index: outIdx, content_index: 0,
+                part: { type: "output_text", text: state.toolCallBuffer }
+              });
+              writeSSE(response, "response.output_item.done", {
+                output_index: outIdx,
+                item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.toolCallBuffer }] }
+              });
+            }
+          }
+        }
+      } else {
+        await consumeTaggedStream(dsResponse.body, (tagged) => {
+          if (tagged.kind === "thinking") {
+            if (!state.reasoningItemId) {
+              state.reasoningItemId = `rs_${randomUUID()}`;
+              writeSSE(response, "response.output_item.added", {
+                output_index: 0,
+                item: { type: "reasoning", id: state.reasoningItemId, summary: [] }
+              });
+            }
+            writeSSE(response, "response.reasoning_text.delta", {
+              output_index: 0, delta: tagged.text
+            });
+            state.reasoningAccumulator += tagged.text;
+            return;
+          }
+
+          const outIdx = textOutputBaseIdx();
+          if (!state.messageItemId) {
+            state.messageItemId = `msg_${randomUUID()}`;
+            writeSSE(response, "response.output_item.added", {
+              output_index: outIdx,
+              item: { id: state.messageItemId, type: "message", role: "assistant", content: [] }
+            });
+            writeSSE(response, "response.content_part.added", {
+              output_index: outIdx, content_index: 0,
+              part: { type: "output_text", text: "" }
+            });
+          }
+          writeSSE(response, "response.output_text.delta", {
+            output_index: outIdx, content_index: 0, delta: tagged.text
+          });
+          state.textAccumulator += tagged.text;
+        });
+
+        if (state.reasoningItemId) {
+          writeSSE(response, "response.reasoning_text.done", {
+            output_index: 0, text: state.reasoningAccumulator
+          });
+          writeSSE(response, "response.output_item.done", {
+            output_index: 0,
+            item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
+          });
+        }
+
+        if (state.messageItemId) {
+          const outIdx = textOutputBaseIdx();
+          writeSSE(response, "response.output_text.done", {
+            output_index: outIdx, content_index: 0, text: state.textAccumulator
+          });
+          writeSSE(response, "response.content_part.done", {
+            output_index: outIdx, content_index: 0,
+            part: { type: "output_text", text: state.textAccumulator }
+          });
+          writeSSE(response, "response.output_item.done", {
+            output_index: outIdx,
+            item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
+          });
+        }
+      }
+
+      writeSSE(response, "response.completed", {
+        id: responseId, object: "response", created_at: created,
+        status: "completed", completed_at: Math.floor(Date.now() / 1000),
+        model: modelId, output: [],
+        usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+      });
+
+      response.end();
+    }
+  });
+}

--- a/src/services/responses-bridge.js
+++ b/src/services/responses-bridge.js
@@ -193,24 +193,30 @@ export async function collectResponsesResult({ account, body, deleteAfterFinish 
   });
 }
 
-function writeSSE(response, event, data) {
-  response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+function createSseWriter(response) {
+  let seq = 0;
+  return function writeSSE(event, data) {
+    const payload = { type: event, sequence_number: seq++, ...data };
+    response.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+  };
 }
 
-function emitResponseTextChunk(response, outIdx, text, state) {
+function emitResponseTextChunk(writeSSE, outIdx, text, state) {
   if (!state.messageItemId) {
     state.messageItemId = `msg_${randomUUID()}`;
-    writeSSE(response, "response.output_item.added", {
+    writeSSE("response.output_item.added", {
       output_index: outIdx,
       item: { id: state.messageItemId, type: "message", role: "assistant", content: [] }
     });
-    writeSSE(response, "response.content_part.added", {
+    writeSSE("response.content_part.added", {
+      item_id: state.messageItemId,
       output_index: outIdx,
       content_index: 0,
       part: { type: "output_text", text: "" }
     });
   }
-  writeSSE(response, "response.output_text.delta", {
+  writeSSE("response.output_text.delta", {
+    item_id: state.messageItemId,
     output_index: outIdx,
     content_index: 0,
     delta: text
@@ -244,8 +250,11 @@ export async function streamResponsesResult({ response, account, body, deleteAft
         status: "in_progress", model: modelId, output: [],
         usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
       };
-      writeSSE(response, "response.created", baseResponse);
-      writeSSE(response, "response.in_progress", baseResponse);
+
+      const writeSSE = createSseWriter(response);
+
+      writeSSE("response.created", { response: baseResponse });
+      writeSSE("response.in_progress", { response: baseResponse });
 
       const state = {
         reasoningItemId: null,
@@ -259,7 +268,7 @@ export async function streamResponsesResult({ response, account, body, deleteAft
       const textOutputBaseIdx = () => state.reasoningItemId ? 1 : 0;
 
       function emitTextChunk(text) {
-        emitResponseTextChunk(response, textOutputBaseIdx(), text, state);
+        emitResponseTextChunk(writeSSE, textOutputBaseIdx(), text, state);
       }
 
       if (requestOptions.tools) {
@@ -267,12 +276,13 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           if (tagged.kind === "thinking") {
             if (!state.reasoningItemId) {
               state.reasoningItemId = `rs_${randomUUID()}`;
-              writeSSE(response, "response.output_item.added", {
+              writeSSE("response.output_item.added", {
                 output_index: 0,
                 item: { type: "reasoning", id: state.reasoningItemId, summary: [] }
               });
             }
-            writeSSE(response, "response.reasoning_text.delta", {
+            writeSSE("response.reasoning_text.delta", {
+              item_id: state.reasoningItemId,
               output_index: 0, delta: tagged.text
             });
             state.reasoningAccumulator += tagged.text;
@@ -320,10 +330,11 @@ export async function streamResponsesResult({ response, account, body, deleteAft
         }
 
         if (state.reasoningItemId) {
-          writeSSE(response, "response.reasoning_text.done", {
+          writeSSE("response.reasoning_text.done", {
+            item_id: state.reasoningItemId,
             output_index: 0, text: state.reasoningAccumulator
           });
-          writeSSE(response, "response.output_item.done", {
+          writeSSE("response.output_item.done", {
             output_index: 0,
             item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
           });
@@ -331,14 +342,16 @@ export async function streamResponsesResult({ response, account, body, deleteAft
 
         if (state.messageItemId) {
           const outIdx = textOutputBaseIdx();
-          writeSSE(response, "response.output_text.done", {
+          writeSSE("response.output_text.done", {
+            item_id: state.messageItemId,
             output_index: outIdx, content_index: 0, text: state.textAccumulator
           });
-          writeSSE(response, "response.content_part.done", {
+          writeSSE("response.content_part.done", {
+            item_id: state.messageItemId,
             output_index: outIdx, content_index: 0,
             part: { type: "output_text", text: state.textAccumulator }
           });
-          writeSSE(response, "response.output_item.done", {
+          writeSSE("response.output_item.done", {
             output_index: outIdx,
             item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
           });
@@ -350,17 +363,17 @@ export async function streamResponsesResult({ response, account, body, deleteAft
             let fcIdx = textOutputBaseIdx() + (state.messageItemId ? 1 : 0);
             for (const tc of toolCalls) {
               const fcId = `fc_${randomUUID()}`;
-              writeSSE(response, "response.output_item.added", {
+              writeSSE("response.output_item.added", {
                 output_index: fcIdx,
                 item: { type: "function_call", id: fcId, call_id: tc.id, name: tc.function.name }
               });
-              writeSSE(response, "response.function_call_arguments.delta", {
+              writeSSE("response.function_call_arguments.delta", {
                 output_index: fcIdx, item_id: fcId, delta: tc.function.arguments
               });
-              writeSSE(response, "response.function_call_arguments.done", {
+              writeSSE("response.function_call_arguments.done", {
                 output_index: fcIdx, item_id: fcId, arguments: tc.function.arguments
               });
-              writeSSE(response, "response.output_item.done", {
+              writeSSE("response.output_item.done", {
                 output_index: fcIdx,
                 item: { type: "function_call", id: fcId, call_id: tc.id, name: tc.function.name, arguments: tc.function.arguments }
               });
@@ -370,14 +383,16 @@ export async function streamResponsesResult({ response, account, body, deleteAft
             emitTextChunk(state.toolCallBuffer);
             if (state.messageItemId) {
               const outIdx = textOutputBaseIdx();
-              writeSSE(response, "response.output_text.done", {
+              writeSSE("response.output_text.done", {
+                item_id: state.messageItemId,
                 output_index: outIdx, content_index: 0, text: state.toolCallBuffer
               });
-              writeSSE(response, "response.content_part.done", {
+              writeSSE("response.content_part.done", {
+                item_id: state.messageItemId,
                 output_index: outIdx, content_index: 0,
                 part: { type: "output_text", text: state.toolCallBuffer }
               });
-              writeSSE(response, "response.output_item.done", {
+              writeSSE("response.output_item.done", {
                 output_index: outIdx,
                 item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.toolCallBuffer }] }
               });
@@ -389,12 +404,13 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           if (tagged.kind === "thinking") {
             if (!state.reasoningItemId) {
               state.reasoningItemId = `rs_${randomUUID()}`;
-              writeSSE(response, "response.output_item.added", {
+              writeSSE("response.output_item.added", {
                 output_index: 0,
                 item: { type: "reasoning", id: state.reasoningItemId, summary: [] }
               });
             }
-            writeSSE(response, "response.reasoning_text.delta", {
+            writeSSE("response.reasoning_text.delta", {
+              item_id: state.reasoningItemId,
               output_index: 0, delta: tagged.text
             });
             state.reasoningAccumulator += tagged.text;
@@ -404,26 +420,29 @@ export async function streamResponsesResult({ response, account, body, deleteAft
           const outIdx = textOutputBaseIdx();
           if (!state.messageItemId) {
             state.messageItemId = `msg_${randomUUID()}`;
-            writeSSE(response, "response.output_item.added", {
+            writeSSE("response.output_item.added", {
               output_index: outIdx,
               item: { id: state.messageItemId, type: "message", role: "assistant", content: [] }
             });
-            writeSSE(response, "response.content_part.added", {
+            writeSSE("response.content_part.added", {
+              item_id: state.messageItemId,
               output_index: outIdx, content_index: 0,
               part: { type: "output_text", text: "" }
             });
           }
-          writeSSE(response, "response.output_text.delta", {
+          writeSSE("response.output_text.delta", {
+            item_id: state.messageItemId,
             output_index: outIdx, content_index: 0, delta: tagged.text
           });
           state.textAccumulator += tagged.text;
         });
 
         if (state.reasoningItemId) {
-          writeSSE(response, "response.reasoning_text.done", {
+          writeSSE("response.reasoning_text.done", {
+            item_id: state.reasoningItemId,
             output_index: 0, text: state.reasoningAccumulator
           });
-          writeSSE(response, "response.output_item.done", {
+          writeSSE("response.output_item.done", {
             output_index: 0,
             item: { type: "reasoning", id: state.reasoningItemId, summary: [{ type: "summary_text", text: state.reasoningAccumulator }] }
           });
@@ -431,25 +450,29 @@ export async function streamResponsesResult({ response, account, body, deleteAft
 
         if (state.messageItemId) {
           const outIdx = textOutputBaseIdx();
-          writeSSE(response, "response.output_text.done", {
+          writeSSE("response.output_text.done", {
+            item_id: state.messageItemId,
             output_index: outIdx, content_index: 0, text: state.textAccumulator
           });
-          writeSSE(response, "response.content_part.done", {
+          writeSSE("response.content_part.done", {
+            item_id: state.messageItemId,
             output_index: outIdx, content_index: 0,
             part: { type: "output_text", text: state.textAccumulator }
           });
-          writeSSE(response, "response.output_item.done", {
+          writeSSE("response.output_item.done", {
             output_index: outIdx,
             item: { type: "message", id: state.messageItemId, role: "assistant", content: [{ type: "output_text", text: state.textAccumulator }] }
           });
         }
       }
 
-      writeSSE(response, "response.completed", {
-        id: responseId, object: "response", created_at: created,
-        status: "completed", completed_at: Math.floor(Date.now() / 1000),
-        model: modelId, output: [],
-        usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+      writeSSE("response.completed", {
+        response: {
+          id: responseId, object: "response", created_at: created,
+          status: "completed", completed_at: Math.floor(Date.now() / 1000),
+          model: modelId, output: [],
+          usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+        }
       });
 
       response.end();


### PR DESCRIPTION
- 在 public/chat-models.js 的 CHAT_MODELS 数组中新增 8 个模型：deepseek-v4-flash、deepseek-v4-flash-search、deepseek-v4-reasoner-flash、deepseek-v4-reasoner-flash-search、deepseek-v4-pro、deepseek-v4-pro-search、deepseek-v4-reasoner-pro、deepseek-v4-reasoner-pro-search
- 在 src/services/openai-request.js 的 BASE_OPENAI_MODELS 数组中新增 4 个模型：deepseek-v4-flash、deepseek-v4-reasoner-flash、deepseek-v4-pro、deepseek-v4-reasoner-pro



<!-- sakura-ai-issue-links-start -->

Resolves #4
Resolves #5

<!-- sakura-ai-issue-links-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**  
重构代理架构并新增 DeepSeek V4 模型支持，将分散的 API 代理统一整合至 v1 路由体系，新增 Anthropic、Responses、Completion 三大桥接服务模块，并完成代码清理与流式输出优化。

**主要改动**  
- **架构重构**：`proxy-routes.js` 移除 OpenAI 旧代理逻辑，新增 `v1-routes.js` 统一路由入口，`server.js` 完成路由对接调整。  
- **新增模块**：`anthropic-bridge.js`、`responses-bridge.js`、`completion-core.js` 实现 Anthropic/Responses/Completion API 完整适配；`responses-bridge` 重构 SSE 流式输出，封装带序列号的 writer 函数，显著优化文本累加与响应结构。  
- **代码优化**：`anthropic-bridge.js` 移除未使用的 `reasoningAccumulator` 变量，减少冗余；`responses-bridge.js` 进一步重构流式处理逻辑（+62/-75），提升稳定性。  
- **Bug 修复**：修复 `anthropic-bridge` 流式处理中思维块未关闭就进入文本或工具块的问题。  
- **模型扩展**：`openai-bridge.js` 新增 DeepSeek V4 适配逻辑，`chat-models.js` 添加对应模型配置。

**影响范围**  
- 代理路由架构整体变更，旧路由逻辑移除，API 入口统一为 v1 路径。  
- DeepSeek V4、Anthropic、Responses 等模型和 API 正式可用，流式输出稳定性进一步提升。  
- 新增模块解耦后便于独立维护，不影响现有其他已适配模型功能。

<!-- sakura-ai-summary-end -->